### PR TITLE
Create a 'commanding' python package, for managing bot commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN pip3 install -r ${MRB_ROOT}/requirements.txt
 # COMMON DOCKERFILE ENDS HERE
 
 ADD bot/mrb/ ${MRB_ROOT}/mrb/
+ADD bot/mrb_common/ ${MRB_ROOT}/mrb_common/
 ADD bot/bot.py ${MRB_ROOT}
 
 CMD python3 bot.py

--- a/bot/mrb/__init__.py
+++ b/bot/mrb/__init__.py
@@ -20,4 +20,4 @@ __all__ = [
     'Player',
 ]
 
-__version__ = "0.3.2"
+__version__ = "0.3.3"

--- a/bot/mrb/__init__.py
+++ b/bot/mrb/__init__.py
@@ -15,8 +15,10 @@ limitations under the License.
 """
 
 from .audio.player import Player
+from .bot_commands import BotCommands
 
 __all__ = [
+    'BotCommands',
     'Player',
 ]
 

--- a/bot/mrb/bot_commands.py
+++ b/bot/mrb/bot_commands.py
@@ -28,6 +28,7 @@ from mrb_common.commanding import (
     Commander,
     CommandResult,
 )
+from .versioning import get_version_command
 
 
 class BotCommands(Commander):
@@ -39,6 +40,10 @@ class BotCommands(Commander):
         self._logger = logger
 
         self.configure_commands({
+            '!version': (
+                get_version_command,
+                "I'll report my current version number to you",
+            ),
         })
 
     def configure_commands(

--- a/bot/mrb/bot_commands.py
+++ b/bot/mrb/bot_commands.py
@@ -1,0 +1,76 @@
+"""
+Copyright 2017 Peter Urda
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import logging
+from typing import (
+    Callable,
+    Dict,
+    Optional,
+    Tuple,
+)
+
+from discord import Message
+
+from mrb_common.commanding import (
+    Commander,
+    CommandResult,
+)
+
+
+class BotCommands(Commander):
+    """Customize, and define, the commands for our main commander in the bot"""
+
+    def __init__(self, logger: logging.Logger):
+        super().__init__()
+
+        self._logger = logger
+
+        self.configure_commands({
+        })
+
+    def configure_commands(
+            self,
+            raw_commands: Dict[str, Tuple[Callable, str]],
+    ):
+        """Configure the commands for this bot, from a raw structure"""
+        for trigger, raw_command in raw_commands.items():
+            command, help_text = raw_command
+            self.add(
+                trigger=trigger,
+                command=command,
+                help_text=help_text,
+            )
+
+    def execute(
+            self,
+            trigger: str,
+            message: Message,
+    ):
+        """Prevent direct access to execute from this class"""
+        raise NotImplementedError("'execute' is not allowed here!")
+
+    def parse_message(self, message: Message) -> Optional[CommandResult]:
+        """Parse a given message for a command token and execute"""
+        tokens = message.content.split()
+        self._logger.log(logging.DEBUG, "tokens: {}".format(tokens))
+
+        command_token = tokens[0] if len(tokens) > 0 else ''
+        self._logger.log(
+            logging.DEBUG,
+            "command_token: {}".format(command_token)
+        )
+
+        return super().execute(command_token, message)

--- a/bot/mrb/versioning.py
+++ b/bot/mrb/versioning.py
@@ -1,0 +1,43 @@
+"""
+Copyright 2017 Peter Urda
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from discord import Message
+
+from mrb_common.commanding import (
+    CommandResult,
+    ResponseType,
+)
+
+
+def get_version() -> str:
+    """Get the raw version string"""
+    return '0.3.3'
+
+
+def get_version_command(message: Message) -> CommandResult:
+    """Generate a version response"""
+    response = (
+        '{user} I am version `{version}` and at your service.'
+    ).format(
+        user=message.author.mention,
+        version=get_version(),
+    )
+
+    return CommandResult(
+        content=response,
+        response_type=ResponseType.ChannelMessage,
+        success=True,
+    )

--- a/bot/mrb_common/__init__.py
+++ b/bot/mrb_common/__init__.py
@@ -1,0 +1,15 @@
+"""
+Copyright 2017 Peter Urda
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""

--- a/bot/mrb_common/commanding/__init__.py
+++ b/bot/mrb_common/commanding/__init__.py
@@ -1,0 +1,27 @@
+"""
+Copyright 2017 Peter Urda
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from .command import Command
+from .command_result import CommandResult
+from .commander import Commander
+from .reponse_type import ResponseType
+
+__all__ = [
+    'Command',
+    'Commander',
+    'CommandResult',
+    'ResponseType',
+]

--- a/bot/mrb_common/commanding/command.py
+++ b/bot/mrb_common/commanding/command.py
@@ -1,0 +1,47 @@
+"""
+Copyright 2017 Peter Urda
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from typing import Callable
+
+from discord import Message
+
+from .command_result import CommandResult
+
+
+class Command(object):
+    def __init__(
+            self,
+            command: Callable[[Message], CommandResult],
+            help_text: str=''
+    ):
+        """
+        Class to represent a "command" for the bot to respond and act on.
+
+        :param command: The actual function to fire
+        :param help_text: The help text for more information
+        """
+
+        self.command = command
+        self.help_text = help_text
+
+    def execute(self, message: Message) -> CommandResult:
+        """
+        Execute the function stored in this command
+
+        :param message: The discord message to pass to the function
+        :return: The CommandResult from the function
+        """
+        return self.command(message)

--- a/bot/mrb_common/commanding/command_result.py
+++ b/bot/mrb_common/commanding/command_result.py
@@ -1,0 +1,31 @@
+"""
+Copyright 2017 Peter Urda
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from .reponse_type import ResponseType
+
+
+class CommandResult(object):
+    def __init__(
+            self,
+            content: str='',
+            error_message: str='',
+            response_type: ResponseType=ResponseType.NoOp,
+            success: bool=False,
+    ):
+        self.content = content
+        self.error_message = error_message
+        self.response_type = response_type
+        self.success = success

--- a/bot/mrb_common/commanding/commander.py
+++ b/bot/mrb_common/commanding/commander.py
@@ -1,0 +1,84 @@
+"""
+Copyright 2017 Peter Urda
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from typing import (
+    Callable,
+    Optional,
+)
+
+from discord import Message
+
+from .command import Command
+from .command_result import CommandResult
+
+
+class Commander(object):
+    def __init__(self):
+        self._commands = {}
+
+    def add(
+            self,
+            trigger: str,
+            command: Callable[[Message], CommandResult],
+            help_text: str=''
+    ):
+        """
+        Add a command to the commander.
+
+        Raises a KeyError if a command already exists with a given trigger.
+
+        :param trigger: The keyword for this command
+        :param command: The function for this command
+        :param help_text: The help text, if available, for more information
+        """
+
+        if trigger in self._commands:
+            raise KeyError("Command '{}' already exists!".format(trigger))
+
+        self._commands[trigger] = Command(command, help_text)
+
+    def execute(
+            self,
+            trigger: str,
+            message: Message,
+    ) -> Optional[CommandResult]:
+        """
+        Have the commander run a desired command from a given trigger.
+
+        :param trigger: The trigger to execute
+        :param message: The discord message to act on
+        :return: A `CommandResult` object, or `None` if no command ran
+        """
+
+        # If there's no matching command listing, just stop now
+        if trigger not in self._commands:
+            return None
+
+        return self._commands[trigger].execute(message)
+
+    def remove(self, trigger: str):
+        """
+        Remove a command from the commander.
+
+        Raises a KeyError if a command does not exist with a given trigger.
+
+        :param trigger: The keyword of the command to remove
+        """
+
+        if trigger not in self._commands:
+            raise KeyError("Command '{}' not found!".format(trigger))
+
+        del self._commands[trigger]

--- a/bot/mrb_common/commanding/reponse_type.py
+++ b/bot/mrb_common/commanding/reponse_type.py
@@ -1,0 +1,23 @@
+"""
+Copyright 2017 Peter Urda
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from enum import Enum
+
+
+class ResponseType(Enum):
+    ChannelMessage = 'channel'
+    DirectMessage = 'dm'
+    NoOp = 'noop'

--- a/tests/unit/mrb/test_bot_commands.py
+++ b/tests/unit/mrb/test_bot_commands.py
@@ -1,0 +1,85 @@
+"""
+Copyright 2017 Peter Urda
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from logging import Logger
+from unittest import TestCase
+from unittest.mock import (
+    call,
+    patch,
+    MagicMock,
+)
+
+from discord import Message
+
+from mrb import BotCommands
+
+
+class TestBotCommands(TestCase):
+    def setUp(self):
+        self.mock_logger = MagicMock(spec=Logger)  # type: Logger
+        self.mock_message = MagicMock(spec=Message)  # type: Message
+        self.bot_commands = BotCommands(
+            logger=self.mock_logger,
+        )
+
+    def test_configure_commands(self):
+        """Verify that commands are configured through the parent's add"""
+        mock_add = MagicMock()
+        raw_input = {}
+        expected_calls = []
+
+        for x in range(3):
+            call_trigger = 'trigger{0}'.format(x)
+            call_command = 'command{0}'.format(x)
+            call_help = 'help_text{0}'.format(x)
+
+            raw_input[call_trigger] = (call_command, call_help)
+            expected_calls.append(call(
+                trigger=call_trigger,
+                command=call_command,
+                help_text=call_help,
+            ))
+
+        self.bot_commands.add = mock_add
+        self.bot_commands.configure_commands(raw_input)
+
+        # We allow any_order here since configure_commands is working with
+        # a dict, and the order will not always be the same
+        mock_add.assert_has_calls(expected_calls, any_order=True)
+
+    def test_execute_raises_error(self):
+        """Verify that calling execute raises an expected exception"""
+        with self.assertRaises(NotImplementedError):
+            self.bot_commands.execute('', self.mock_message)
+
+    def test_logger_defined(self):
+        """Verify the logger is attached to the object"""
+        self.assertEqual(self.bot_commands._logger, self.mock_logger)
+
+    @patch('mrb_common.commanding.commander.Commander.execute')
+    def test_parse_message(self, mock_super_execute):
+        """
+        Verify that parsing calls the parent object with a token and message
+
+        :type mock_super_execute: MagicMock
+        """
+        token = '!token'
+        content = 'content'
+        self.mock_message.content = '{0} {1}'.format(token, content)
+
+        self.bot_commands.parse_message(self.mock_message)
+
+        mock_super_execute.assert_called_with(token, self.mock_message)

--- a/tests/unit/mrb/test_versioning.py
+++ b/tests/unit/mrb/test_versioning.py
@@ -1,0 +1,87 @@
+"""
+Copyright 2017 Peter Urda
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from discord import (
+    Message,
+    User,
+)
+
+from mrb import versioning
+from mrb_common.commanding import (
+    CommandResult,
+    ResponseType,
+)
+
+
+class TestGetVersion(TestCase):
+    def test_type(self):
+        """Verify that a type of string is returned"""
+        self.assertIsInstance(versioning.get_version(), str)
+
+    def test_non_zero_length(self):
+        """Verify that a non-zero length string is returned"""
+        self.assertGreater(len(versioning.get_version()), 0)
+
+
+class TestGetVersionCommand(TestCase):
+    def setUp(self):
+        self.user = User(
+            name='TestUser',
+            id='TestUserId',
+            discriminator='0000',
+            avatar='',
+            bot=False,
+        )
+
+        self.mock_message = MagicMock(spec=Message)  # type: Message
+        self.mock_message.author = self.user
+
+    def test_type(self):
+        """Verify that the correct result type is returned"""
+        self.assertIsInstance(
+            versioning.get_version_command(self.mock_message),
+            CommandResult,
+        )
+
+    def test_response_content_user_mention(self):
+        """Verify that the version command mentions the user"""
+        self.assertIn(
+            self.user.mention,
+            versioning.get_version_command(self.mock_message).content,
+        )
+
+    def test_response_content_version_value(self):
+        """Verify that the version command contains the version"""
+        self.assertIn(
+            versioning.get_version(),
+            versioning.get_version_command(self.mock_message).content,
+        )
+
+    def test_response_success(self):
+        """Verify that the response is always successful"""
+        self.assertTrue(
+            versioning.get_version_command(self.mock_message).success
+        )
+
+    def test_response_type(self):
+        """Verify that the version command is a channel response type"""
+        self.assertEqual(
+            versioning.get_version_command(self.mock_message).response_type,
+            ResponseType.ChannelMessage,
+        )

--- a/tests/unit/mrb_common/commanding/test_command.py
+++ b/tests/unit/mrb_common/commanding/test_command.py
@@ -1,0 +1,42 @@
+"""
+Copyright 2017 Peter Urda
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from discord import Message
+
+from mrb_common.commanding import Command
+
+
+class TestCommand(TestCase):
+    def setUp(self):
+        self.mock_function = MagicMock()
+        self.mock_message = MagicMock(spec=Message)  # type: Message
+
+    def test_exec(self):
+        """Verify that calling exec on a command runs the stored function"""
+        command = Command(self.mock_function)
+        command.execute(self.mock_message)
+
+        self.assertEqual(self.mock_function.call_count, 1)
+
+    def test_exec_called_with_message(self):
+        """Verify that calling exec passes a message along to the function"""
+        command = Command(self.mock_function)
+        command.execute(self.mock_message)
+
+        self.mock_function.assert_called_with(self.mock_message)

--- a/tests/unit/mrb_common/commanding/test_command_result.py
+++ b/tests/unit/mrb_common/commanding/test_command_result.py
@@ -1,0 +1,28 @@
+"""
+Copyright 2017 Peter Urda
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from unittest import TestCase
+
+from mrb_common.commanding import CommandResult
+
+
+class TestCommandResult(TestCase):
+    def setUp(self):
+        self.command_result = CommandResult()
+
+    def test_result_create(self):
+        """Verify the proper initial state of a result object"""
+        self.assertFalse(self.command_result.success)

--- a/tests/unit/mrb_common/commanding/test_commander.py
+++ b/tests/unit/mrb_common/commanding/test_commander.py
@@ -1,0 +1,60 @@
+"""
+Copyright 2017 Peter Urda
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from discord import Message
+
+from mrb_common.commanding import Commander
+
+
+class TestCommander(TestCase):
+    def setUp(self):
+        self.commander = Commander()
+
+    def test_add(self):
+        """Verify commands can be added"""
+        self.commander.add('test', MagicMock())
+        self.assertEqual(len(self.commander._commands), 1)
+
+    def test_add_duplicate(self):
+        """Verify a KeyError is raised when adding a duplicate command"""
+        self.commander.add('test', MagicMock())
+        with self.assertRaises(KeyError):
+            self.commander.add('test', MagicMock())
+
+    def test_execute(self):
+        """Verify commands can be executed"""
+        mock_function = MagicMock()
+        self.commander.add('test', mock_function)
+        self.commander.execute('test', MagicMock(spec=Message))
+        self.assertEqual(mock_function.call_count, 1)
+
+    def test_execute_undefined(self):
+        """Verify no-op occurs when an undefined command is executed"""
+        self.commander.execute('test', MagicMock(spec=Message))
+
+    def test_remove(self):
+        """Verify commands can be removed"""
+        self.commander.add('test', MagicMock())
+        self.commander.remove('test')
+        self.assertEqual(len(self.commander._commands), 0)
+
+    def test_remove_undefined(self):
+        """Verify a KeyError is raised when removing an undefined command"""
+        with self.assertRaises(KeyError):
+            self.commander.remove('test')


### PR DESCRIPTION
As the `bot` grows, it will be important to manage the core commands and functions that it can perform. For this, I have considered a `commander` like object that will be able to manage the possible commands performed by the bot. Basically, minimizing the actual code that has to be written into the `main` for the actual `bot` program.