### PR TITLE
Release '0.3.4'

### DIFF
--- a/bot/bot.py
+++ b/bot/bot.py
@@ -26,7 +26,7 @@ import discord
 import mrb
 import mrb.environment
 import mrb.fun
-from mrb.versioning import get_version
+import mrb.versioning
 from mrb_common.commanding import ResponseType
 
 # Get the env details
@@ -59,8 +59,17 @@ logger.addHandler(stdout_logger)
 client = discord.Client()
 player = mrb.Player()
 
+bot_raw_commands = {
+    '!version': (
+        mrb.versioning.get_version_command,
+        "I'll report my current version number to you",
+    ),
+}
 
-bot_commands = mrb.BotCommands(logger)
+bot_commands = mrb.BotCommands(
+    commands=bot_raw_commands,
+    logger=logger,
+)
 
 
 def get_help_message(audio_list: List[str]=None) -> str:
@@ -337,7 +346,10 @@ async def on_ready():
         )
 
     logger.log(logging.INFO, '---')
-    logger.log(logging.INFO, "Version: '{}'".format(get_version()))
+    logger.log(
+        logging.INFO,
+        "Version: '{}'".format(mrb.versioning.get_version()),
+    )
 
     logger.log(logging.INFO, '---')
 

--- a/bot/mrb/bot_commands.py
+++ b/bot/mrb/bot_commands.py
@@ -34,8 +34,14 @@ from .versioning import get_version_command
 class BotCommands(Commander):
     """Customize, and define, the commands for our main commander in the bot"""
 
-    def __init__(self, logger: logging.Logger):
+    def __init__(
+            self,
+            logger: logging.Logger=None,
+    ):
         super().__init__()
+
+        if logger and not isinstance(logger, logging.Logger):
+            raise TypeError("You must use a proper logging.Logger type!")
 
         self._logger = logger
 
@@ -45,6 +51,13 @@ class BotCommands(Commander):
                 "I'll report my current version number to you",
             ),
         })
+
+    def _log(self, level: int, msg: str, *args, **kwargs):
+        """Internal wrapper for the logger, in case one is not set"""
+        if not self._logger:
+            return
+
+        self._logger.log(level, msg, args, **kwargs)
 
     def configure_commands(
             self,
@@ -70,12 +83,9 @@ class BotCommands(Commander):
     def parse_message(self, message: Message) -> Optional[CommandResult]:
         """Parse a given message for a command token and execute"""
         tokens = message.content.split()
-        self._logger.log(logging.DEBUG, "tokens: {}".format(tokens))
+        self._log(logging.DEBUG, "tokens: {}".format(tokens))
 
         command_token = tokens[0] if len(tokens) > 0 else ''
-        self._logger.log(
-            logging.DEBUG,
-            "command_token: {}".format(command_token)
-        )
+        self._log(logging.DEBUG, "command_token: {}".format(command_token))
 
         return super().execute(command_token, message)

--- a/bot/mrb/versioning.py
+++ b/bot/mrb/versioning.py
@@ -24,7 +24,7 @@ from mrb_common.commanding import (
 
 def get_version() -> str:
     """Get the raw version string"""
-    return '0.3.3'
+    return '0.3.4'
 
 
 def get_version_command(message: Message) -> CommandResult:

--- a/bot/mrb_common/commanding/commander.py
+++ b/bot/mrb_common/commanding/commander.py
@@ -27,7 +27,12 @@ from .command_result import CommandResult
 
 class Commander(object):
     def __init__(self):
-        self._commands = {}
+        # Define object attributes to avoid
+        # "Instance attribute defined outside __init__"
+        self._commands = None
+
+        # Actually configure the Commander
+        self.reset()
 
     def add(
             self,
@@ -82,3 +87,7 @@ class Commander(object):
             raise KeyError("Command '{}' not found!".format(trigger))
 
         del self._commands[trigger]
+
+    def reset(self):
+        """Reset the commander to the initial state"""
+        self._commands = {}

--- a/tests/unit/mrb/test_bot_commands.py
+++ b/tests/unit/mrb/test_bot_commands.py
@@ -67,6 +67,36 @@ class TestBotCommands(TestCase):
         """Verify the logger is attached to the object"""
         self.assertEqual(self.bot_commands._logger, self.mock_logger)
 
+    def test_logger_as_none(self):
+        """Verify that we do not have to define a logger"""
+        self.bot_commands = BotCommands()
+        self.assertIsNone(self.bot_commands._logger)
+        self.bot_commands = BotCommands(logger=None)
+        self.assertIsNone(self.bot_commands._logger)
+
+    def test_logger_raises_type_error(self):
+        """Verify that a non logging.Logger object raises a TypeError"""
+        with self.assertRaises(TypeError):
+            # noinspection PyTypeChecker
+            BotCommands(logger='not a logger')
+
+    def test_logging_internal(self):
+        """Verify that we are calling loggers correctly internally"""
+        level = 0
+        message = 'test'
+        self.mock_logger.log = MagicMock()
+
+        self.bot_commands = BotCommands(logger=self.mock_logger)
+        self.bot_commands._log(level, message)
+
+        # noinspection PyUnresolvedReferences
+        self.mock_logger.log.assert_called_with(level, message, ())
+
+    def test_logging_internal_no_logger(self):
+        """Verify that trying to log with no logger does nothing"""
+        self.bot_commands = BotCommands()
+        self.bot_commands._log(0, 'test')
+
     @patch('mrb_common.commanding.commander.Commander.execute')
     def test_parse_message(self, mock_super_execute):
         """

--- a/tests/unit/mrb/test_bot_commands.py
+++ b/tests/unit/mrb/test_bot_commands.py
@@ -31,9 +31,7 @@ class TestBotCommands(TestCase):
     def setUp(self):
         self.mock_logger = MagicMock(spec=Logger)  # type: Logger
         self.mock_message = MagicMock(spec=Message)  # type: Message
-        self.bot_commands = BotCommands(
-            logger=self.mock_logger,
-        )
+        self.bot_commands = BotCommands(logger=self.mock_logger)
 
     def test_configure_commands(self):
         """Verify that commands are configured through the parent's add"""

--- a/tests/unit/mrb_common/commanding/test_commander.py
+++ b/tests/unit/mrb_common/commanding/test_commander.py
@@ -48,6 +48,11 @@ class TestCommander(TestCase):
         """Verify no-op occurs when an undefined command is executed"""
         self.commander.execute('test', MagicMock(spec=Message))
 
+    def test_init(self):
+        """Verify that init configures the object correctly"""
+        self.assertIsInstance(self.commander._commands, dict)
+        self.assertEqual(len(self.commander._commands), 0)
+
     def test_remove(self):
         """Verify commands can be removed"""
         self.commander.add('test', MagicMock())
@@ -58,3 +63,10 @@ class TestCommander(TestCase):
         """Verify a KeyError is raised when removing an undefined command"""
         with self.assertRaises(KeyError):
             self.commander.remove('test')
+
+    def test_reset(self):
+        """Verify reset actually resets the commander"""
+        self.commander.add('test', MagicMock())
+        self.assertEqual(len(self.commander._commands), 1)
+        self.commander.reset()
+        self.assertEqual(len(self.commander._commands), 0)

--- a/tests/unit/mrb_common/commanding/test_commander.py
+++ b/tests/unit/mrb_common/commanding/test_commander.py
@@ -40,13 +40,15 @@ class TestCommander(TestCase):
     def test_execute(self):
         """Verify commands can be executed"""
         mock_function = MagicMock()
+        mock_message = MagicMock(spec=Message)  # type: Message
         self.commander.add('test', mock_function)
-        self.commander.execute('test', MagicMock(spec=Message))
+        self.commander.execute('test', mock_message)
         self.assertEqual(mock_function.call_count, 1)
 
     def test_execute_undefined(self):
         """Verify no-op occurs when an undefined command is executed"""
-        self.commander.execute('test', MagicMock(spec=Message))
+        mock_message = MagicMock(spec=Message)  # type: Message
+        self.commander.execute('test', mock_message)
 
     def test_init(self):
         """Verify that init configures the object correctly"""


### PR DESCRIPTION
- Logging is now optional in the `BotCommands`
- Commands are configured outside `BotCommands` instead of interanlly
- `Commander` can now be "reset", allowing commands to be erased